### PR TITLE
test: add unit tests for TextInput component and update Button tests …

### DIFF
--- a/test/Button.spec.ts
+++ b/test/Button.spec.ts
@@ -15,7 +15,9 @@ describe('ButtonComponent', () => {
   })
 
   it('emits the click event', async () => {
-    const wrapper = shallowMount(Button)
+    const wrapper = shallowMount(Button, {
+      props: { label: '' },
+    })
 
     await wrapper.find('input').trigger('click')
 

--- a/test/TextInput.spec.ts
+++ b/test/TextInput.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, shallowMount } from '@vue/test-utils'
+import { TextInput } from '../src'
+
+describe('TextInputComponent', () => {
+  it('renders the slot content', () => {
+    const label = 'Enter text'
+    const wrapper = mount(TextInput, {
+      props: { inputId: 'text-input' },
+      slots: { default: label },
+    })
+    expect(wrapper.text()).toContain(label)
+  })
+
+  it('sets the id attribute on the textarea', () => {
+    const wrapper = shallowMount(TextInput, {
+      props: { inputId: 'text-area' },
+    })
+    const textarea = wrapper.find('textarea')
+    expect(textarea.attributes('id')).toBe('text-area')
+  })
+
+  it('emits update:modelValue when textarea value changes', async () => {
+    const wrapper = shallowMount(TextInput, {
+      props: { inputId: 'text-input', modelValue: '' },
+    })
+    const textarea = wrapper.find('textarea')
+    await textarea.setValue('Hello World')
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['Hello World'])
+  })
+
+  it('focuses textarea when container is clicked', async () => {
+    const wrapper = mount(TextInput, {
+      props: { inputId: 'focus-test' },
+    })
+    const textareaEl = wrapper.find('textarea').element as HTMLTextAreaElement
+    const focusSpy = vi.spyOn(textareaEl, 'focus')
+    await wrapper.find('div').trigger('click')
+    expect(focusSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
…with props

This pull request improves test coverage for the `Button` and `TextInput` components by adding new tests and updating existing ones. The most important changes include adding a new test suite for `TextInput` and updating the `Button` component test to include a required prop.

### Test additions for `TextInput`:

* [`test/TextInput.spec.ts`](diffhunk://#diff-2520601ad822c4a3ccbbe8852df3437859237c4ff1dfdfb79dd71b552c622578R1-R42): Added a comprehensive test suite for the `TextInput` component, including tests for rendering slot content, setting the `id` attribute, emitting `update:modelValue` on value change, and focusing the textarea when the container is clicked.

### Updates to `Button` component tests:

* [`test/Button.spec.ts`](diffhunk://#diff-1dc0db9eb10c6cc0f3b4389f1c36393bbd665710980136911bb6a34571e5dbfdL18-R20): Updated the test for the `Button` component to include the `label` prop, ensuring proper initialization of the component.