### PR TITLE
feat: add search term functionality to MultipleSelect component and u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,12 @@ A multi-select component featuring a customizable input field, allowing for dyna
 - Type: `string[]`
 - Description: Binds the array of selected items.
 
-**Usage:**
+**v-model:searchTerm:**
+
+- Type: `string`
+- Description: Binds the current search term typed in the input, for custom logic or display.
+
+**Usage with searchTerm:**
 
 ```vue
 <script setup>
@@ -173,13 +178,20 @@ import { MultipleSelect } from 'formify-vue'
 import { ref } from 'vue'
 
 const selectedItems = ref([])
+const searchValue = ref('')
 const options = ['Option 1', 'Option 2', 'Option 3']
 </script>
 
 <template>
-  <MultipleSelect inputId="multi-select" v-model="selectedItems" :autocompleteOptions="options"
-    >Select Items</MultipleSelect
+  <MultipleSelect
+    inputId="multi-select"
+    v-model="selectedItems"
+    v-model:searchTerm="searchValue"
+    :autocompleteOptions="options"
   >
+    Select Items
+  </MultipleSelect>
+  <p>Current search term: {{ searchValue }}</p>
 </template>
 ```
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ const multipleSelect = ref<string[]>([])
 const autocompleteSelect = ref<string[]>([])
 const autocompleteDuplicatesSelect = ref<string[]>([])
 const autocompleteNoCustomSelect = ref<string[]>([])
+const searchTermDemo = ref('')
 </script>
 
 <template>
@@ -75,6 +76,18 @@ const autocompleteNoCustomSelect = ref<string[]>([])
       input-id="select-input"
       >Test</Select
     >
+    <div class="m-4">
+      <label for="search-term-demo" class="mb-2 block font-semibold">Search-term demo:</label>
+      <MultipleSelect
+        input-id="search-term-demo"
+        v-model="multipleSelect"
+        v-model:searchTerm="searchTermDemo"
+        :autocomplete-options="['Apple', 'Banana', 'Cherry']"
+      >
+        Type to filter
+      </MultipleSelect>
+      <p class="mt-2">Currently typing: {{ searchTermDemo }}</p>
+    </div>
     <Slider></Slider>
     <Slider :max="100" :min="0" :step="1" :markers="[0, 25, 50, 75, 100]"></Slider>
     <TextInput class="h-50" input-id="text-input"></TextInput>

--- a/src/MultipleSelect.vue
+++ b/src/MultipleSelect.vue
@@ -19,9 +19,25 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  searchTerm: {
+    type: String,
+    default: '',
+  },
 })
+const emit = defineEmits<(e: 'update:searchTerm', value: string) => void>()
 const inputRef: Ref<HTMLInputElement | null> = ref(null)
-const inputValue = ref('')
+const inputValue = ref(props.searchTerm)
+
+watch(inputValue, (val) => {
+  emit('update:searchTerm', val)
+})
+watch(
+  () => props.searchTerm,
+  (val) => {
+    if (val !== inputValue.value) inputValue.value = val
+  },
+)
+
 const isInputFocused = ref(false)
 const activeIndex = ref(-1)
 

--- a/test/MultipleSelect.spec.ts
+++ b/test/MultipleSelect.spec.ts
@@ -196,4 +196,23 @@ describe('MultipleSelectComponent', () => {
 
     expect(wrapper.html()).toContain('OptionB')
   })
+
+  it('emits update:searchTerm when typing in the input', async () => {
+    const wrapper = mount(MultipleSelect, {
+      props: { inputId: 'search', autocompleteOptions: [] },
+    })
+    const input = wrapper.find('input')
+    await input.setValue('test')
+    expect(wrapper.emitted('update:searchTerm')).toBeTruthy()
+    expect(wrapper.emitted('update:searchTerm')![0]).toEqual(['test'])
+  })
+
+  it('updates input value when searchTerm prop changes', async () => {
+    const wrapper = mount(MultipleSelect, {
+      props: { inputId: 'search', searchTerm: 'initial', autocompleteOptions: [] },
+    })
+    expect(wrapper.find('input').element.value).toBe('initial')
+    await wrapper.setProps({ searchTerm: 'newValue' })
+    expect(wrapper.find('input').element.value).toBe('newValue')
+  })
 })

--- a/test/MultipleSelect.spec.ts
+++ b/test/MultipleSelect.spec.ts
@@ -202,9 +202,16 @@ describe('MultipleSelectComponent', () => {
       props: { inputId: 'search', autocompleteOptions: [] },
     })
     const input = wrapper.find('input')
+    // type a value and assert emission count and payload
     await input.setValue('test')
-    expect(wrapper.emitted('update:searchTerm')).toBeTruthy()
-    expect(wrapper.emitted('update:searchTerm')![0]).toEqual(['test'])
+    const emitted1 = wrapper.emitted('update:searchTerm')
+    expect(emitted1).toHaveLength(1)
+    expect(emitted1![0]).toEqual(['test'])
+    // clear the input and verify another emission with empty string
+    await input.setValue('')
+    const emitted2 = wrapper.emitted('update:searchTerm')
+    expect(emitted2).toHaveLength(2)
+    expect(emitted2![1]).toEqual([''])
   })
 
   it('updates input value when searchTerm prop changes', async () => {


### PR DESCRIPTION
This pull request introduces a new feature to the `MultipleSelect` component that enables two-way binding for a `searchTerm` prop. It also adds a demo implementation in `App.vue` and corresponding tests to validate the functionality.

### Feature Addition: `searchTerm` Prop in `MultipleSelect`

* **Two-way binding for `searchTerm`:** Added a `searchTerm` prop to the `MultipleSelect` component, allowing the input field value to be dynamically updated and emitting changes via the `update:searchTerm` event. (`src/MultipleSelect.vue`, [src/MultipleSelect.vueR22-R40](diffhunk://#diff-9019f9b9d957c63d0bcb52f6ebe31efc12eaed2843ccbff3a928a3609fe76e4eR22-R40))

### Demo Implementation in `App.vue`

* **Search-term demo UI:** Integrated the `searchTerm` feature into `App.vue` with a demo section that showcases filtering options and displays the currently typed value. (`src/App.vue`, [src/App.vueR79-R90](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R79-R90))
* **Reactive variable for `searchTerm`:** Added a `searchTermDemo` reactive variable to manage the state of the demo implementation. (`src/App.vue`, [src/App.vueR9](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R9))

### Testing Enhancements

* **Unit tests for `searchTerm`:** Added tests to ensure the `MultipleSelect` component emits the `update:searchTerm` event correctly and updates the input value when the `searchTerm` prop changes. (`test/MultipleSelect.spec.ts`, [test/MultipleSelect.spec.tsR199-R217](diffhunk://#diff-834bca31f0acce948d77f289de0cf016a6ce0e81ca128a1aac28df633efe513bR199-R217))…pdate tests