### PR TITLE
feat: improve option scrolling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,7 +64,7 @@ const searchTermDemo = ref('')
     <MultipleSelect
       input-id="multiple-select-input"
       v-model="autocompleteNoCustomSelect"
-      :autocomplete-options="['test', 'test2']"
+      :autocomplete-options="['test', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7']"
       :allow-custom="false"
       >Test</MultipleSelect
     >

--- a/src/MultipleSelect.vue
+++ b/src/MultipleSelect.vue
@@ -60,7 +60,7 @@ watch(activeIndex, async (newIndex) => {
   if (!list) return
   const optionEl = list.children[newIndex] as HTMLElement
   if (optionEl && typeof optionEl.scrollIntoView === 'function') {
-    optionEl.scrollIntoView({ block: 'nearest' })
+    optionEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }
 })
 

--- a/src/MultipleSelect.vue
+++ b/src/MultipleSelect.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { InputLabel } from './index.ts'
 import { CancelIcon } from './icons'
-import { ref, computed, watch, type Ref, ModelRef } from 'vue'
+import { ref, computed, watch, type Ref, ModelRef, nextTick } from 'vue'
 
 const model: ModelRef<string[]> = defineModel<string[]>({ default: [] })
 
@@ -40,6 +40,7 @@ watch(
 
 const isInputFocused = ref(false)
 const activeIndex = ref(-1)
+const optionsListRef: Ref<HTMLUListElement | null> = ref(null)
 
 const filteredOptions = computed(() =>
   props.autocompleteOptions.filter(
@@ -51,6 +52,16 @@ const filteredOptions = computed(() =>
 
 watch([inputValue, isInputFocused, filteredOptions], () => {
   activeIndex.value = -1
+})
+watch(activeIndex, async (newIndex) => {
+  if (newIndex < 0) return
+  await nextTick()
+  const list = optionsListRef.value
+  if (!list) return
+  const optionEl = list.children[newIndex] as HTMLElement
+  if (optionEl && typeof optionEl.scrollIntoView === 'function') {
+    optionEl.scrollIntoView({ block: 'nearest' })
+  }
 })
 
 const addItem = (item: string) => {
@@ -139,6 +150,7 @@ const onOptionMouseDown = (item: string, event: MouseEvent) => {
       />
     </div>
     <ul
+      ref="optionsListRef"
       v-if="isInputFocused && filteredOptions.length"
       class="absolute left-0 z-10 mt-1 max-h-40 w-full overflow-auto rounded-md border border-gray-300 bg-white shadow-lg"
     >

--- a/test/MultipleSelect.spec.ts
+++ b/test/MultipleSelect.spec.ts
@@ -1,14 +1,23 @@
-import { describe, expect, it, vi, beforeAll, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeAll, afterEach, afterAll } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
 import { MultipleSelect } from '../src'
 import { nextTick } from 'vue'
 
 describe('MultipleSelectComponent', () => {
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView
   beforeAll(() => {
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
       writable: true,
       value: () => {},
+    })
+  })
+  afterAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: originalScrollIntoView,
     })
   })
   afterEach(() => vi.restoreAllMocks())

--- a/test/MultipleSelect.spec.ts
+++ b/test/MultipleSelect.spec.ts
@@ -1,14 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeAll, afterEach } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
 import { MultipleSelect } from '../src'
-
-async function setInputValue(wrapper: any, value: string) {
-  const input = wrapper.find('input')
-  input.setValue(value)
-  await input.trigger('input')
-}
+import { nextTick } from 'vue'
 
 describe('MultipleSelectComponent', () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: () => {},
+    })
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  async function setInputValue(wrapper: any, value: string) {
+    const input = wrapper.find('input')
+    input.setValue(value)
+    await input.trigger('input')
+  }
+
   it('renders the slot content', () => {
     const text = 'Hello'
     const wrapper = mount(MultipleSelect, {
@@ -201,25 +211,36 @@ describe('MultipleSelectComponent', () => {
     const wrapper = mount(MultipleSelect, {
       props: { inputId: 'search', autocompleteOptions: [] },
     })
-    const input = wrapper.find('input')
     // type a value and assert emission count and payload
-    await input.setValue('test')
+    await setInputValue(wrapper, 'test')
     const emitted1 = wrapper.emitted('update:searchTerm')
     expect(emitted1).toHaveLength(1)
     expect(emitted1![0]).toEqual(['test'])
     // clear the input and verify another emission with empty string
-    await input.setValue('')
+    await setInputValue(wrapper, '')
     const emitted2 = wrapper.emitted('update:searchTerm')
     expect(emitted2).toHaveLength(2)
     expect(emitted2![1]).toEqual([''])
   })
 
-  it('updates input value when searchTerm prop changes', async () => {
+  it('calls scrollIntoView on the active option with smooth behavior', async () => {
+    const options = ['One', 'Two', 'Three', 'Four']
     const wrapper = mount(MultipleSelect, {
-      props: { inputId: 'search', searchTerm: 'initial', autocompleteOptions: [] },
+      props: { inputId: 'tag-input', autocompleteOptions: options },
+      attachTo: document.body,
     })
-    expect(wrapper.find('input').element.value).toBe('initial')
-    await wrapper.setProps({ searchTerm: 'newValue' })
-    expect(wrapper.find('input').element.value).toBe('newValue')
+    // populate options and focus
+    await setInputValue(wrapper, '')
+    await wrapper.find('input').trigger('focus')
+    const items = wrapper.findAll('ul li')
+    // spy on scrollIntoView of the second option
+    const targetEl = items[1].element as HTMLElement
+    const spy = vi.spyOn(targetEl, 'scrollIntoView')
+    // move activeIndex to 1
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    // wait for watcher nextTick
+    await nextTick()
+    expect(spy).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' })
   })
 })

--- a/test/MultipleSelect.spec.ts
+++ b/test/MultipleSelect.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeAll, afterEach, afterAll } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
 import { MultipleSelect } from '../src'
+import type { VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 
 describe('MultipleSelectComponent', () => {
@@ -22,7 +23,7 @@ describe('MultipleSelectComponent', () => {
   })
   afterEach(() => vi.restoreAllMocks())
 
-  async function setInputValue(wrapper: any, value: string) {
+  async function setInputValue(wrapper: VueWrapper<any>, value: string) {
     const input = wrapper.find('input')
     input.setValue(value)
     await input.trigger('input')


### PR DESCRIPTION
This pull request includes updates to enhance the functionality of the `MultipleSelect` component and improve the user experience. The most significant changes involve adding new autocomplete options, implementing smooth scrolling to active options, and introducing a new ref for the options list.

### Enhancements to `MultipleSelect` functionality:

* **Expanded autocomplete options**: Updated the `autocomplete-options` in `src/App.vue` to include additional values (`['test3', 'test4', 'test5', 'test6', 'test7']`) for a richer selection experience.

* **Smooth scrolling to active options**: Added a `watch` on `activeIndex` in `src/MultipleSelect.vue` to scroll the active option into view when navigating the list. This ensures better accessibility and usability.

* **Options list ref**: Introduced `optionsListRef` in `src/MultipleSelect.vue` to facilitate direct manipulation of the options list DOM element for scrolling functionality. [[1]](diffhunk://#diff-9019f9b9d957c63d0bcb52f6ebe31efc12eaed2843ccbff3a928a3609fe76e4eR43) [[2]](diffhunk://#diff-9019f9b9d957c63d0bcb52f6ebe31efc12eaed2843ccbff3a928a3609fe76e4eR153)

### Code improvements:

* **Added `nextTick` from Vue**: Imported `nextTick` in `src/MultipleSelect.vue` to handle asynchronous updates when scrolling the active option into view.